### PR TITLE
Allow bot to listen to all messages on a channel

### DIFF
--- a/slackbot-listen.html
+++ b/slackbot-listen.html
@@ -1,18 +1,22 @@
-
 <script type="text/x-red" data-template-name="slackbot-listen">
 
    <div class="form-row">
         <label for="node-input-slackbot"> Slackbot Token</label>
         <input type="text" id="node-input-slackbot">
     </div>
-    
+
     <!-- By convention, most nodes have a 'name' property. The following div -->
     <!-- provides the necessary field. Should always be the last option      -->
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Name of this Node">
     </div>
-    
+
+    <div class="form-row">
+        <label>&nbsp;</label>
+        <input type="checkbox" id="node-input-ambient" placeholder="" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-ambient" style="width: 70%;">Listen to all messages?</label>
+    </div>
 </script>
 
 
@@ -34,18 +38,19 @@
 <script type="text/javascript">
     RED.nodes.registerType('slackbot-listen', {
         category: 'chat',
-        defaults: {    
+        defaults: {
             slackbot: {value:"", type:"slackbot-controller"},
-            name: {value:""}
+            name: {value:""},
+            ambient: {value:false}
         },
         inputs:0,               // set the number of inputs - only 0 or 1
         outputs:1,              // set the number of outputs - 0 to n
         icon: "slack.png",     // saved in  icons/myicon.png
-        color: "#EAA820", 
+        color: "#EAA820",
         label: function() {
             return this.name || "Slack Listen";
         },
         paletteLabel: "Slack Listen"
-        
+
     });
 </script>

--- a/slackbot-listen.js
+++ b/slackbot-listen.js
@@ -4,15 +4,15 @@ module.exports = function(RED) {
     'use strict';
 
     function Node(n) {
-      
+
         RED.nodes.createNode(this,n);
 
         var node = this;
-        
+
         var slackbot = RED.nodes.getNode(n.slackbot);
-        
+
         if (slackbot.bot_token) {
-            
+
             node.controller = Botkit.slackbot({
                 debug: false,
             });
@@ -20,21 +20,27 @@ module.exports = function(RED) {
             node.bot = this.controller.spawn({
                 token: slackbot.bot_token
             }).startRTM();
-            
+
         }
 
-        node.controller.on('direct_message,direct_mention,mention',function(bot, message) {
-            
-            var msg = { 
+        var events = 'direct_message,direct_mention,mention';
+
+        if (n.ambient) {
+            events = events + ',ambient';
+        }
+
+        node.controller.on(events,function(bot, message) {
+
+            var msg = {
                 message: message,
-                payload: message.text 
+                payload: message.text
             };
-            
+
             console.log(msg);
-            
+
             node.send(msg);
         });
-        
+
         node.on('close', function(done) {
             node.controller.shutdown();
             node.bot.closeRTM();


### PR DESCRIPTION
By default, the bot will only receive messages directed at it, either by mention in the channel, or by direct message. With the added option in the Listen-node, the bot will receive all messages in a given channel. The default however remains as before, so updating an existing bot should not have any impact.