### PR TITLE
Add a retry count to ensure the bot stays up

### DIFF
--- a/slackbot-controller.js
+++ b/slackbot-controller.js
@@ -3,7 +3,6 @@ module.exports = function(RED) {
     function SlackbotNode(n) {
         RED.nodes.createNode(this,n);
         this.bot_token = n.bot_token;
-        this.bot_retries = 500;
     }
     RED.nodes.registerType("slackbot-controller", SlackbotNode);
 }

--- a/slackbot-controller.js
+++ b/slackbot-controller.js
@@ -3,6 +3,7 @@ module.exports = function(RED) {
     function SlackbotNode(n) {
         RED.nodes.createNode(this,n);
         this.bot_token = n.bot_token;
+
     }
     RED.nodes.registerType("slackbot-controller", SlackbotNode);
 }

--- a/slackbot-controller.js
+++ b/slackbot-controller.js
@@ -3,7 +3,7 @@ module.exports = function(RED) {
     function SlackbotNode(n) {
         RED.nodes.createNode(this,n);
         this.bot_token = n.bot_token;
-
+        this.bot_retries = 500;
     }
     RED.nodes.registerType("slackbot-controller", SlackbotNode);
 }

--- a/slackbot-listen.js
+++ b/slackbot-listen.js
@@ -10,6 +10,16 @@ module.exports = function(RED) {
         var node = this;
         
         var slackbot = RED.nodes.getNode(n.slackbot);
+
+        function start_rtm() {
+            node.bot.startRTM(function(err,bot,payload) {
+                if (err) {
+                        console.log('Failed to start RTM')
+                        return setTimeout(start_rtm, 60000);
+                }
+                console.log("RTM started!");
+            });
+        }
         
         if (slackbot.bot_token) {
             
@@ -19,10 +29,14 @@ module.exports = function(RED) {
 
             node.bot = this.controller.spawn({
                 token: slackbot.bot_token,
-                retry: slackbot.bot_retries,
-            }).startRTM();
+            });
             
+            start_rtm();
         }
+
+        node.controller.on('rtm_close', function(bot, err) {
+            start_rtm();
+        });
 
         node.controller.on('direct_message,direct_mention,mention',function(bot, message) {
             

--- a/slackbot-listen.js
+++ b/slackbot-listen.js
@@ -14,10 +14,8 @@ module.exports = function(RED) {
         function start_rtm() {
             node.bot.startRTM(function(err,bot,payload) {
                 if (err) {
-                        console.log('Failed to start RTM')
-                        return setTimeout(start_rtm, 60000);
+                    setTimeout(start_rtm, 5000);
                 }
-                console.log("RTM started!");
             });
         }
         

--- a/slackbot-listen.js
+++ b/slackbot-listen.js
@@ -18,7 +18,8 @@ module.exports = function(RED) {
             });
 
             node.bot = this.controller.spawn({
-                token: slackbot.bot_token
+                token: slackbot.bot_token,
+                retry: slackbot.bot_retries,
             }).startRTM();
             
         }

--- a/slackbot-reply.js
+++ b/slackbot-reply.js
@@ -14,10 +14,8 @@ module.exports = function(RED) {
         function start_rtm() {
             node.bot.startRTM(function(err,bot,payload) {
                 if (err) {
-                        console.log('Failed to start RTM')
-                        return setTimeout(start_rtm, 60000);
+                    setTimeout(start_rtm, 5000);
                 }
-                console.log("RTM started!");
             });
         }
         

--- a/slackbot-reply.js
+++ b/slackbot-reply.js
@@ -10,6 +10,16 @@ module.exports = function(RED) {
         var node = this;
         
         var slackbot = RED.nodes.getNode(n.slackbot);
+
+        function start_rtm() {
+            node.bot.startRTM(function(err,bot,payload) {
+                if (err) {
+                        console.log('Failed to start RTM')
+                        return setTimeout(start_rtm, 60000);
+                }
+                console.log("RTM started!");
+            });
+        }
         
         if (slackbot.bot_token) {
             
@@ -19,10 +29,14 @@ module.exports = function(RED) {
 
             node.bot = this.controller.spawn({
                 token: slackbot.bot_token,
-                retry: slackbot.bot_retries,
-            }).startRTM();
+            });
             
+            start_rtm();
         }
+
+        node.controller.on('rtm_close', function(bot, err) {
+            start_rtm();
+        });
         
         this.on('input', function (msg) {
 

--- a/slackbot-reply.js
+++ b/slackbot-reply.js
@@ -18,7 +18,8 @@ module.exports = function(RED) {
             });
 
             node.bot = this.controller.spawn({
-                token: slackbot.bot_token
+                token: slackbot.bot_token,
+                retry: slackbot.bot_retries,
             }).startRTM();
             
         }


### PR DESCRIPTION
This will make the node more stable, when using slack. Currently, the bot drops off after an unspecified interval.

BotKit has a retry param, that we can use to make it more reliable:
https://github.com/howdyai/botkit/issues/104
https://github.com/howdyai/botkit/issues/261